### PR TITLE
Converted the code to use winsock 2

### DIFF
--- a/oncrpc/Bindresv.c
+++ b/oncrpc/Bindresv.c
@@ -84,7 +84,7 @@ bindresvport(sd, sin)
 #define ENDPORT (IPPORT_RESERVED - 1)
 #define NPORTS	(ENDPORT - STARTPORT + 1)
 
-	if (sin == (struct sockaddr_in *)0) {
+	if (sin == (struct sockaddr_in *)NULL) {
 		sin = &myaddr;
 //		bzero(sin, sizeof (*sin));
 		bzero((char *)sin, sizeof (*sin));

--- a/oncrpc/Get_myad.c
+++ b/oncrpc/Get_myad.c
@@ -79,22 +79,21 @@ get_myaddress(addr)
 	struct sockaddr_in *addr;
 {
 #ifdef _WIN32
-struct hostent	*Hostent;
-char my_name[MAX_NAME_LEN];
+	char my_name[MAX_NAME_LEN];
+	PADDRINFOA addressInfo = NULL;
 
 	gethostname(my_name, MAX_NAME_LEN);
-	Hostent = gethostbyname(my_name);
+	int error = getaddrinfo(my_name, NULL, NULL, &addressInfo);
 
-	if (Hostent == NULL) {
-		errno;
+	if (error != 0 || addressInfo == NULL || addressInfo->ai_family != AF_INET) {
 		perror("Can not get host info");
-		exit (1);
+		exit(1);
 	}
 
-	addr->sin_family = AF_INET;
+	struct sockaddr_in* address = (struct sockaddr_in*)addressInfo->ai_addr;
+	addr->sin_family = addressInfo->ai_family;
 	addr->sin_port = htons(PMAPPORT);
-	bcopy((char *)Hostent->h_addr, (char *)&addr->sin_addr, 
-							Hostent->h_length);
+	bcopy((char *)&address->sin_addr, (char *)&addr->sin_addr, sizeof(IN_ADDR));
 
 #else	
 	int s;

--- a/oncrpc/Getrpcpo.c
+++ b/oncrpc/Getrpcpo.c
@@ -69,12 +69,15 @@ getrpcport(host, prognum, versnum, proto)
 	char *host;
 {
 	struct sockaddr_in addr;
-	struct hostent *hp;
+	PADDRINFOA addressInfo = NULL;
 
-	if ((hp = gethostbyname(host)) == NULL)
+	if (getaddrinfo(host, NULL, NULL, &addressInfo) != 0 || addressInfo == NULL || addressInfo->ai_family != AF_INET) {
 		return (0);
-	bcopy(hp->h_addr, (char *) &addr.sin_addr, hp->h_length);
-	addr.sin_family = AF_INET;
+	}
+	struct sockaddr_in* address = (struct sockaddr_in*)addressInfo->ai_addr;
+	bcopy((char*)&address->sin_addr, (char *) &addr.sin_addr, sizeof(IN_ADDR));
+	addr.sin_family = addressInfo->ai_family;
+	//addr.sin_family = AF_INET;
 	addr.sin_port =  0;
 	return (pmap_getport(&addr, prognum, versnum, proto));
 }

--- a/oncrpc/Pmap_cln.c
+++ b/oncrpc/Pmap_cln.c
@@ -82,7 +82,7 @@ pmap_set(program, version, protocol, port)
 	u_short port;
 {
 	struct sockaddr_in myaddress;
-	int socket = -1;
+	socket_t socket = { .fd = RPC_ANYSOCK };
 	register CLIENT *client;
 	struct pmap parms;
 	bool_t rslt;
@@ -103,9 +103,9 @@ pmap_set(program, version, protocol, port)
 	}
 	CLNT_DESTROY(client);
 #ifdef _WIN32
-	(void)closesocket(socket);
+	(void)closesocket(socket.socket);
 #else
-	(void)close(socket);
+	(void)close(socket.socket);
 #endif
 	return (rslt);
 }
@@ -120,7 +120,7 @@ pmap_unset(program, version)
 	u_long version;
 {
 	struct sockaddr_in myaddress;
-	int socket = -1;
+	socket_t socket = { .fd = RPC_ANYSOCK };
 	register CLIENT *client;
 	struct pmap parms;
 	bool_t rslt;
@@ -137,9 +137,9 @@ pmap_unset(program, version)
 		pmap_totTimeout);
 	CLNT_DESTROY(client);
 #ifdef _WIN32
-	(void)closesocket(socket);
+	(void)closesocket(socket.socket);
 #else
-	(void)close(socket);
+	(void)close(socket.socket);
 #endif
 	return (rslt);
 }

--- a/oncrpc/Svc.c
+++ b/oncrpc/Svc.c
@@ -113,7 +113,7 @@ void
 xprt_register(xprt)
 	SVCXPRT *xprt;
 {
-	register int sock = xprt->xp_sock;
+	socket_t sock = xprt->xp_sock;
 
 #ifdef FD_SETSIZE
 	if (xports == NULL) {
@@ -121,7 +121,7 @@ xprt_register(xprt)
 			mem_alloc(FD_SETSIZE * sizeof(SVCXPRT *));
 	}
 #ifdef _WIN32
-	while (sock >= sizeof_xports) {
+	while (sock.socket >= sizeof_xports) {
 		SVCXPRT **old_xports;
 
 		old_xports = xports;
@@ -133,28 +133,28 @@ xprt_register(xprt)
 
 
 	if (svc_fdset.fd_count < FD_SETSIZE) {
-		xports[sock] = xprt;
-		FD_SET(sock, &svc_fdset);
+		xports[sock.socket] = xprt;
+		FD_SET(sock.socket, &svc_fdset);
 	} else {
 		char str[256];
 		
 #ifdef _WIN32
-		sprintf_s(str, sizeof(str), "too many connections (%d), compilation constant FD_SETSIZE was only %d", sock, FD_SETSIZE);
+		sprintf_s(str, sizeof(str), "too many connections (%d), compilation constant FD_SETSIZE was only %d", sock.fd, FD_SETSIZE);
 #else
-		snprintf(str, sizeof(str), "too many connections (%d), compilation constant FD_SETSIZE was only %d", sock, FD_SETSIZE);
+		snprintf(str, sizeof(str), "too many connections (%d), compilation constant FD_SETSIZE was only %d", sock.fd, FD_SETSIZE);
 #endif
 		nt_rpc_report(str);
 	}
 #else
 	if (sock < _rpc_dtablesize()) {
-		xports[sock] = xprt;
-		FD_SET(sock, &svc_fdset);
+		xports[sock.socket] = xprt;
+		FD_SET(sock.socket, &svc_fdset);
 	}
 #endif
 #else
-	if (sock < NOFILE) {
-		xports[sock] = xprt;
-		svc_fds |= (1 << sock);
+	if (sock.fd < NOFILE) {
+		xports[sock.socket] = xprt;
+		svc_fds |= (1 << sock.socket);
 	}
 #endif /* def FD_SETSIZE */
 
@@ -167,22 +167,22 @@ void
 xprt_unregister(xprt) 
 	SVCXPRT *xprt;
 { 
-	register int sock = xprt->xp_sock;
+	socket_t sock = xprt->xp_sock;
 
 #ifdef FD_SETSIZE
 #ifdef _WIN32
-	if ((xports[sock] == xprt)) {
-		xports[sock] = (SVCXPRT *)0;
-		FD_CLR((unsigned)sock, &svc_fdset);
+	if ((xports[sock.socket] == xprt)) {
+		xports[sock.socket] = (SVCXPRT *)0;
+		FD_CLR(sock.socket, &svc_fdset);
 #else
-	if ((sock < _rpc_dtablesize()) && (xports[sock] == xprt)) {
-		xports[sock] = (SVCXPRT *)0;
-		FD_CLR(sock, &svc_fdset);
+	if ((sock < _rpc_dtablesize()) && (xports[sock.socket] == xprt)) {
+		xports[sock.socket] = (SVCXPRT *)0;
+		FD_CLR(sock.socket, &svc_fdset);
 #endif
 	}
 #else
-	if ((sock < NOFILE) && (xports[sock] == xprt)) {
-		xports[sock] = (SVCXPRT *)0;
+	if ((sock < NOFILE) && (xports[sock.socket] == xprt)) {
+		xports[sock.socket] = (SVCXPRT *)0;
 		svc_fds &= ~(1 << sock);
 	}
 #endif /* def FD_SETSIZE */

--- a/oncrpc/Svc_simp.c
+++ b/oncrpc/Svc_simp.c
@@ -95,7 +95,8 @@ registerrpc(prognum, versnum, procnum, progname, inproc, outproc)
 		return (-1);
 	}
 	if (transp == 0) {
-		transp = svcudp_create(RPC_ANYSOCK);
+		socket_t socket = { .fd = RPC_ANYSOCK };
+		transp = svcudp_create(socket);
 		if (transp == NULL) {
 #ifdef _WIN32
 			nt_rpc_report("couldn't create an rpc server\n");

--- a/oncrpc/Svc_tcp.c
+++ b/oncrpc/Svc_tcp.c
@@ -154,10 +154,7 @@ struct tcp_conn {  /* kept in xprt->xp_p1 */
  * 0 => use the system default.
  */
 SVCXPRT *
-svctcp_create(sock, sendsize, recvsize)
-	register int sock;
-	u_int sendsize;
-	u_int recvsize;
+svctcp_create(socket_t sock, u_int sendsize, u_int recvsize)
 {
 	bool_t madesock = FALSE;
 	register SVCXPRT *xprt;
@@ -165,11 +162,11 @@ svctcp_create(sock, sendsize, recvsize)
 	struct sockaddr_in addr;
 	int len = sizeof(struct sockaddr_in);
 
-	if (sock == RPC_ANYSOCK) {
+	if (sock.fd == RPC_ANYSOCK) {
 #ifdef _WIN32
-		if ((sock = socket(AF_INET, SOCK_STREAM, 0)) == INVALID_SOCKET) {
+		if ((sock.socket = socket(AF_INET, SOCK_STREAM, 0)) == INVALID_SOCKET) {
 #else
-		if ((sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
+		if ((sock.socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
 #endif
 			perror("svctcp_.c - udp socket creation problem");
 			return ((SVCXPRT *)NULL);
@@ -178,18 +175,19 @@ svctcp_create(sock, sendsize, recvsize)
 	}
 	bzero((char *)&addr, sizeof (addr));
 	addr.sin_family = AF_INET;
-	if (bindresvport(sock, &addr)) {
+	if (bindresvport(sock.socket, &addr)) {
 		addr.sin_port = 0;
-		(void)bind(sock, (struct sockaddr *)&addr, len);
+		(void)bind(sock.socket, (struct sockaddr *)&addr, len);
 	}
-	if ((getsockname(sock, (struct sockaddr *)&addr, &len) != 0)  ||
-	    (listen(sock, 2) != 0)) {
+	if ((getsockname(sock.socket, (struct sockaddr *)&addr, &len) != 0)  ||
+	    (listen(sock.socket, 2) != 0)) {
 		perror("svctcp_.c - cannot getsockname or listen");
 		if (madesock)
 #ifdef _WIN32
-		       (void)closesocket(sock);
+			shutdown(sock.socket, SD_BOTH);
+		    (void)closesocket(sock.socket);
 #else
-		       (void)close(sock);
+		       (void)close(sock.socket);
 #endif
 		return ((SVCXPRT *)NULL);
 	}
@@ -275,7 +273,7 @@ makefd_xprt(fd, sendsize, recvsize)
 	xprt->xp_addrlen = 0;
 	xprt->xp_ops = &svctcp_op;  /* truely deals with calls */
 	xprt->xp_port = 0;  /* this is a connection, not a rendezvouser */
-	xprt->xp_sock = fd;
+	xprt->xp_sock.fd = fd;
 	xprt_register(xprt);
     done:
 	return (xprt);
@@ -293,7 +291,7 @@ rendezvous_request(xprt)
 	r = (struct tcp_rendezvous *)xprt->xp_p1;
     again:
 	len = sizeof(struct sockaddr_in);
-	if ((sock = accept(xprt->xp_sock, (struct sockaddr *)&addr,
+	if ((sock = accept(xprt->xp_sock.socket, (struct sockaddr *)&addr,
 	    &len)) < 0) {
 #ifdef _WIN32
 		if (WSAerrno == WSAEINTR)
@@ -327,9 +325,10 @@ svctcp_destroy(xprt)
 
 	xprt_unregister(xprt);
 #ifdef _WIN32
-	(void)closesocket(xprt->xp_sock);
+	shutdown(xprt->xp_sock.socket, SD_BOTH);
+	(void)closesocket(xprt->xp_sock.socket);
 #else
-	(void)close(xprt->xp_sock);
+	(void)close(xprt->xp_sock.socket);
 #endif
 	if (xprt->xp_port != 0) {
 		/* a rendezvouser socket */
@@ -359,13 +358,13 @@ readtcp(xprt, buf, len)
 	caddr_t buf;
 	register int len;
 {
-	register int sock = xprt->xp_sock;
+	socket_t sock = xprt->xp_sock;
 #ifdef FD_SETSIZE
 	fd_set mask;
 	fd_set readfds;
 
 	FD_ZERO(&mask);
-	FD_SET(sock, &mask);
+	FD_SET(sock.socket, &mask);
 #else
 	register int mask = 1 << sock;
 	int readfds;
@@ -388,14 +387,14 @@ readtcp(xprt, buf, len)
 			goto fatal_err;
 		}
 #ifdef FD_SETSIZE
-	} while (!FD_ISSET(sock, &readfds));
+	} while (!FD_ISSET(sock.socket, &readfds));
 #else
 	} while (readfds != mask);
 #endif /* def FD_SETSIZE */
 #ifdef _WIN32
-	if ((len = recv(sock, buf, len, 0)) > 0) {
+	if ((len = recv(sock.socket, buf, len, 0)) > 0) {
 #else
-	if ((len = read(sock, buf, len)) > 0) {
+	if ((len = read(sock.socket, buf, len)) > 0) {
 #endif
 		return (len);
 	}
@@ -418,9 +417,9 @@ writetcp(xprt, buf, len)
 
 	for (cnt = len; cnt > 0; cnt -= i, buf += i) {
 #ifdef _WIN32
-		if ((i = send(xprt->xp_sock, buf, cnt, 0)) < 0) {
+		if ((i = send(xprt->xp_sock.socket, buf, cnt, 0)) < 0) {
 #else
-		if ((i = write(xprt->xp_sock, buf, cnt)) < 0) {
+		if ((i = write(xprt->xp_sock.socket, buf, cnt)) < 0) {
 #endif
 			((struct tcp_conn *)(xprt->xp_p1))->strm_stat =
 			    XPRT_DIED;

--- a/oncrpc/Svc_udp.c
+++ b/oncrpc/Svc_udp.c
@@ -122,9 +122,7 @@ static void cache_set(SVCXPRT *xprt, u_long replylen);
  * The routines returns NULL if a problem occurred.
  */
 SVCXPRT *
-svcudp_bufcreate(sock, sendsz, recvsz)
-	register int sock;
-	u_int sendsz, recvsz;
+svcudp_bufcreate(socket_t sock, u_int sendsz, u_int recvsz)
 {
 	bool_t madesock = FALSE;
 	register SVCXPRT *xprt;
@@ -132,11 +130,11 @@ svcudp_bufcreate(sock, sendsz, recvsz)
 	struct sockaddr_in addr;
 	int len = sizeof(struct sockaddr_in);
 
-	if (sock == RPC_ANYSOCK) {
+	if (sock.fd == RPC_ANYSOCK) {
 #ifdef _WIN32
-		if ((sock = socket(AF_INET, SOCK_DGRAM, 0)) == INVALID_SOCKET) {
+		if ((sock.socket = socket(AF_INET, SOCK_DGRAM, 0)) == INVALID_SOCKET) {
 #else
-		if ((sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
+		if ((sock.socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
 #endif
 			perror("svcudp_create: socket creation problem");
 			return ((SVCXPRT *)NULL);
@@ -145,17 +143,17 @@ svcudp_bufcreate(sock, sendsz, recvsz)
 	}
 	bzero((char *)&addr, sizeof (addr));
 	addr.sin_family = AF_INET;
-	if (bindresvport(sock, &addr)) {
+	if (bindresvport(sock.socket, &addr)) {
 		addr.sin_port = 0;
-		(void)bind(sock, (struct sockaddr *)&addr, len);
+		(void)bind(sock.socket, (struct sockaddr *)&addr, len);
 	}
-	if (getsockname(sock, (struct sockaddr *)&addr, &len) != 0) {
+	if (getsockname(sock.socket, (struct sockaddr *)&addr, &len) != 0) {
 		perror("svcudp_create - cannot getsockname");
 		if (madesock)
 #ifdef _WIN32
-			(void)closesocket(sock);
+			(void)closesocket(sock.socket);
 #else
-			(void)close(sock);
+			(void)close(sock.socket);
 #endif
 		return ((SVCXPRT *)NULL);
 	}
@@ -199,10 +197,8 @@ svcudp_bufcreate(sock, sendsz, recvsz)
 }
 
 SVCXPRT *
-svcudp_create(sock)
-	int sock;
+svcudp_create(socket_t sock)
 {
-
 	return(svcudp_bufcreate(sock, UDPMSGSIZE, UDPMSGSIZE));
 }
 
@@ -227,7 +223,7 @@ svcudp_recv(xprt, msg)
 
     again:
 	xprt->xp_addrlen = sizeof(struct sockaddr_in);
-	rlen = recvfrom(xprt->xp_sock, rpc_buffer(xprt), (int) su->su_iosz,
+	rlen = recvfrom(xprt->xp_sock.socket, rpc_buffer(xprt), (int) su->su_iosz,
 	    0, (struct sockaddr *)&(xprt->xp_raddr), &(xprt->xp_addrlen));
 #ifdef _WIN32
 	if (rlen == -1 && WSAerrno == WSAEINTR)
@@ -245,9 +241,9 @@ svcudp_recv(xprt, msg)
 	if (su->su_cache != NULL) {
 		if (cache_get(xprt, msg, &reply, &replylen)) {
 #ifdef _WIN32
-			  sendto(xprt->xp_sock, reply, (int) replylen, 0,
+			  sendto(xprt->xp_sock.socket, reply, (int) replylen, 0,
 #else
-			(void) sendto(xprt->xp_sock, reply, (int) replylen, 0,
+			(void) sendto(xprt->xp_sock.socket, reply, (int) replylen, 0,
 #endif
 			  (struct sockaddr *) &xprt->xp_raddr, xprt->xp_addrlen);
 			return (TRUE);
@@ -271,7 +267,7 @@ svcudp_reply(xprt, msg)
 	msg->rm_xid = su->su_xid;
 	if (xdr_replymsg(xdrs, msg)) {
 		slen = (int)XDR_GETPOS(xdrs);
-		if (sendto(xprt->xp_sock, rpc_buffer(xprt), slen, 0,
+		if (sendto(xprt->xp_sock.socket, rpc_buffer(xprt), slen, 0,
 		    (struct sockaddr *)&(xprt->xp_raddr), xprt->xp_addrlen)
 		    == slen) {
 			stat = TRUE;
@@ -313,9 +309,9 @@ svcudp_destroy(xprt)
 
 	xprt_unregister(xprt);
 #ifdef _WIN32
-	(void)closesocket(xprt->xp_sock);
+	(void)closesocket(xprt->xp_sock.socket);
 #else
-	(void)close(xprt->xp_sock);
+	(void)close(xprt->xp_sock.socket);
 #endif
 	XDR_DESTROY(&(su->su_xdrs));
 	mem_free(rpc_buffer(xprt), su->su_iosz);

--- a/oncrpc/all_oncrpc.h
+++ b/oncrpc/all_oncrpc.h
@@ -47,7 +47,6 @@
 #include <sys/types.h>
 #include <io.h>
 #include <errno.h>
-#include <winsock.h>
 
 #else  /* not _WIN32 */
 #ifndef DllExport

--- a/oncrpc/nt.c
+++ b/oncrpc/nt.c
@@ -33,11 +33,11 @@ int rpc_nt_init(void)
     if (init++)
 	return 0;
 	
-    if (WSAStartup(0x0101, &WSAData)) {
-	init = 0;
-	nt_rpc_report("WSAStartup failed\n");
-	WSACleanup();
-	return -1;
+    if (WSAStartup(MAKEWORD(2,2), &WSAData)) {
+	    init = 0;
+	    nt_rpc_report("WSAStartup failed\n");
+	    WSACleanup();
+	    return -1;
     }
 
     return 0;

--- a/oncrpc/pmap_get.c
+++ b/oncrpc/pmap_get.c
@@ -82,7 +82,7 @@ pmap_getport(address, program, version, protocol)
 	u_int protocol;
 {
 	u_short port = 0;
-	int socket = -1;
+	socket_t socket = { .fd = RPC_ANYSOCK };
 	register CLIENT *client;
 	struct pmap parms;
 
@@ -94,6 +94,7 @@ pmap_getport(address, program, version, protocol)
 		parms.pm_vers = version;
 		parms.pm_prot = protocol;
 		parms.pm_port = 0;  /* not needed or used */
+
 		if (CLNT_CALL(client, PMAPPROC_GETPORT, xdr_pmap, &parms,
 		    xdr_u_short, &port, pmap_totTimeout) != RPC_SUCCESS){
 			rpc_createerr.cf_stat = RPC_PMAPFAILURE;
@@ -103,7 +104,7 @@ pmap_getport(address, program, version, protocol)
 		}
 		CLNT_DESTROY(client);
 	}
-	(void)closesocket(socket);
+	(void)closesocket(socket.socket);
 	address->sin_port = 0;
 	return (port);
 }

--- a/oncrpc/pmap_gma.c
+++ b/oncrpc/pmap_gma.c
@@ -86,8 +86,8 @@ pmap_getmaps(address)
 	 struct sockaddr_in *address;
 {
 	struct pmaplist *head = (struct pmaplist *)NULL;
-	int socket = -1;
 	struct timeval minutetimeout;
+	socket_t socket = { .fd = RPC_ANYSOCK };
 	register CLIENT *client;
 
 	address->sin_port = htons(PMAPPORT);
@@ -101,9 +101,10 @@ pmap_getmaps(address)
 		CLNT_DESTROY(client);
 	}
 #ifdef _WIN32
-	(void)closesocket(socket);
+	shutdown(socket.socket, SD_BOTH);
+	(void)closesocket(socket.socket);
 #else
-	(void)close(socket);
+	(void)close(socket.socket);
 #endif
 	address->sin_port = 0;
 	return (head);

--- a/oncrpc/svc_raw.c
+++ b/oncrpc/svc_raw.c
@@ -106,7 +106,7 @@ svcraw_create()
 		if (srp == 0)
 			return (0);
 	}
-	srp->server.xp_sock = 0;
+	srp->server.xp_sock.fd = 0;
 	srp->server.xp_port = 0;
 	srp->server.xp_ops = &server_ops;
 	srp->server.xp_verf.oa_base = srp->verf_body;

--- a/rpc/rpc/Rpc.h
+++ b/rpc/rpc/Rpc.h
@@ -71,8 +71,10 @@
 #define DllImport	__declspec( dllimport )
 
 #include <stdlib.h>
-#include <windows.h>
-#include <winsock.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <Windows.h>
+#include <stdio.h>
 #include <rpc/types.h>		/* some typedefs */
 #include <process.h>
 #include <rpc/bcopy.h>

--- a/rpc/rpc/svc.h
+++ b/rpc/rpc/svc.h
@@ -97,7 +97,7 @@ enum xprt_stat {
  * Server side transport handle
  */
 typedef struct {
-	int		xp_sock;
+	socket_t xp_sock;
 	u_short		xp_port;	 /* associated port number */
 	struct xp_ops {
 	    bool_t	(*xp_recv)();	 /* receive incomming requests */
@@ -307,8 +307,8 @@ DllExport SVCXPRT *svcraw_create();
 /*
  * Udp based rpc.
  */
-DllExport SVCXPRT *svcudp_create();
-DllExport SVCXPRT *svcudp_bufcreate();
+DllExport SVCXPRT *svcudp_create(socket_t sock);
+DllExport SVCXPRT *svcudp_bufcreate(socket_t sock, u_int sendsz, u_int recvsz);
 
 /*
  * Tcp based rpc.

--- a/rpc/rpc/types.h
+++ b/rpc/rpc/types.h
@@ -57,6 +57,8 @@
  */
 /*      @(#)types.h 1.18 87/07/24 SMI      */
 
+#include <stdint.h>
+
 /*
  * Rpc additions to <sys/types.h>
  */
@@ -74,6 +76,12 @@
 #define __dontcare__	-1
 #ifndef NULL
 #	define NULL 0
+#endif
+
+#if defined(_WIN64) || defined(__X86_64__) || defined(__ppc64__)
+#define __64BIT_ENV__
+#else
+#define __32BIT_ENV__
 #endif
 
 #ifndef _WIN32
@@ -100,5 +108,22 @@ typedef char *caddr_t;
 typedef unsigned int u_int;
 typedef unsigned long u_long;
 typedef unsigned short u_short;
+
+#ifdef _WIN32
+typedef union {
+	SOCKET socket;
+#ifdef __64BIT_ENV__
+	int64_t fd;
+#else
+	int32_t fd;
+#endif
+} socket_t;
+#else
+typedef union
+{
+	int socket;
+	int fd;
+} socket_t;
+#endif
 
 #endif /* ndef __TYPES_RPC_HEADER__ */

--- a/winopenvxi/vxi11_svc.c
+++ b/winopenvxi/vxi11_svc.c
@@ -17,7 +17,8 @@ void vxi11_svc_main()
 	(void)pmap_unset(DEVICE_ASYNC, DEVICE_ASYNC_VERSION);
 	(void)pmap_unset(DEVICE_CORE, DEVICE_CORE_VERSION);
 
-	transp = svcudp_create(RPC_ANYSOCK);
+	socket_t socket = { .fd = RPC_ANYSOCK };
+	transp = svcudp_create(socket);
 	if (transp == NULL) {
 		(void)fprintf(stderr, "cannot create udp service.\n");
 #ifdef _WIN32


### PR DESCRIPTION
Added shutdown to every close socket where a TCP socket would be closed
to make the shutdown more friendly.
Created a `socket_t` union because window's `SOCKET` type is an unsigned
32bit integer on WIN32 but a unsigned 64bit integer on WIN64. But the
code expects a signed int in a lot of spaces so this is a compromise.