### PR TITLE
Enabled SDL checks and fixed all the errors.

### DIFF
--- a/example/example.c
+++ b/example/example.c
@@ -18,7 +18,7 @@ int main(int argc, char** argv)
     CLIENT* VXI11Client = 0;
 
     if (argc > 1) {
-        strncpy(host, argv[1], sizeof(host));
+        strcpy_s(host, sizeof(host), argv[1]);
     }
     for (int n = 0, a = 2; a < argc && n < sizeof(DataWrite) - 2; a += 1) {
         snprintf(DataWrite + n, sizeof(DataWrite) - n - 2, " %s\n", argv[a]);
@@ -76,7 +76,7 @@ int main(int argc, char** argv)
         toret = -1;
         goto End;
     }
-    strncpy(DataRead, rresp->data.data_val, rresp->data.data_len);
+    strncpy_s(DataRead, sizeof(DataRead), rresp->data.data_val, rresp->data.data_len);
     DataRead[rresp->data.data_len] = 0;
 
     printf("%s> %s\n", host, DataRead);

--- a/example/example.vcxproj
+++ b/example/example.vcxproj
@@ -85,7 +85,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>false</SDLCheck>
+      <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)winopenvxi;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -101,7 +101,7 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>false</SDLCheck>
+      <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)winopenvxi;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -117,7 +117,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>false</SDLCheck>
+      <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)winopenvxi;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -133,7 +133,7 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>false</SDLCheck>
+      <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)winopenvxi;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/oncrpc/Clnt_tcp.c
+++ b/oncrpc/Clnt_tcp.c
@@ -141,7 +141,7 @@ clnttcp_create(raddr, prog, vers, sockp, sendsz, recvsz)
 	u_int recvsz;
 {
 	CLIENT *h;
-	register struct ct_data *ct;
+	register struct ct_data *ct = NULL;
 	struct timeval now;
 	struct rpc_msg call_msg;
 

--- a/oncrpc/Clnt_udp.c
+++ b/oncrpc/Clnt_udp.c
@@ -136,7 +136,7 @@ clntudp_bufcreate(raddr, program, version, wait, sockp, sendsz, recvsz)
 	u_int recvsz;
 {
 	CLIENT *cl;
-	register struct cu_data *cu;
+	register struct cu_data *cu = NULL;
 	struct timeval now;
 	struct rpc_msg call_msg;
 

--- a/oncrpc/Pmap_rmt.c
+++ b/oncrpc/Pmap_rmt.c
@@ -311,7 +311,11 @@ clnt_broadcast(prog, vers, proc, xargs, argsp, xresults, resultsp, eachresult)
 	baddr.sin_addr.s_addr = htonl(INADDR_ANY);
 /*	baddr.sin_addr.S_un.S_addr = htonl(INADDR_ANY); */
 	(void)gettimeofday(&t, (struct timezone *)0);
+#ifdef _WIN32
+	msg.rm_xid = xid = _getpid() ^ t.tv_sec ^ t.tv_usec;
+#else
 	msg.rm_xid = xid = getpid() ^ t.tv_sec ^ t.tv_usec;
+#endif
 	t.tv_usec = 0;
 	msg.rm_direction = CALL;
 	msg.rm_call.cb_rpcvers = RPC_MSG_VERSION;

--- a/oncrpc/Svc.c
+++ b/oncrpc/Svc.c
@@ -138,7 +138,11 @@ xprt_register(xprt)
 	} else {
 		char str[256];
 		
-		sprintf(str, "too many connections (%d), compilation constant FD_SETSIZE was only %d", sock, FD_SETSIZE);
+#ifdef _WIN32
+		sprintf_s(str, sizeof(str), "too many connections (%d), compilation constant FD_SETSIZE was only %d", sock, FD_SETSIZE);
+#else
+		snprintf(str, sizeof(str), "too many connections (%d), compilation constant FD_SETSIZE was only %d", sock, FD_SETSIZE);
+#endif
 		nt_rpc_report(str);
 	}
 #else

--- a/oncrpc/Svc_autu.c
+++ b/oncrpc/Svc_autu.c
@@ -128,7 +128,7 @@ _svcauth_unix(rqst, msg)
 		if ((u_int)((5 + gid_len) * BYTES_PER_XDR_UNIT + str_len) > auth_len) {
 #ifdef _WIN32
 			char str[256];
-			sprintf(str, "bad auth_len gid %d str %d auth %d\n",
+			sprintf_s(str, sizeof(str), "bad auth_len gid %d str %d auth %d\n",
 			    gid_len, str_len, auth_len);
 			nt_rpc_report(str);
 #else

--- a/oncrpc/Xdr_rec.c
+++ b/oncrpc/Xdr_rec.c
@@ -442,7 +442,11 @@ xdrrec_getpos(xdrs)
 	register RECSTREAM *rstrm = (RECSTREAM *)xdrs->x_private;
 	register long pos;
 
+#ifdef _WIN32
+	pos = _lseek((int)rstrm->tcp_handle, 0, 1);
+#else
 	pos = lseek((int)rstrm->tcp_handle, (long) 0, 1);
+#endif
 	if (pos != -1)
 		switch (xdrs->x_op) {
 

--- a/oncrpc/clnt_sim.c
+++ b/oncrpc/clnt_sim.c
@@ -96,8 +96,9 @@ callrpc(host, prognum, versnum, procnum, inproc, in, outproc, out)
 			return (0);
 		callrpc_private = crp;
 	}
+	const size_t oldhostSize = 256;
 	if (crp->oldhost == NULL) {
-		crp->oldhost = malloc(256);
+		crp->oldhost = malloc(oldhostSize);
 		crp->oldhost[0] = 0;
 		crp->socket = RPC_ANYSOCK;
 	}
@@ -129,7 +130,11 @@ callrpc(host, prognum, versnum, procnum, inproc, in, outproc, out)
 		crp->valid = 1;
 		crp->oldprognum = prognum;
 		crp->oldversnum = versnum;
-		(void) strcpy(crp->oldhost, host);
+#ifdef _WIN32
+		strcpy_s(crp->oldhost, oldhostSize, host);
+#else
+		strncpy(crp->oldhost, host, oldhostSize);
+#endif
 	}
 	tottimeout.tv_sec = 25;
 	tottimeout.tv_usec = 0;

--- a/oncrpc/nt.c
+++ b/oncrpc/nt.c
@@ -54,7 +54,7 @@ int rpc_nt_exit(void)
 VOID
 nt_rpc_report(LPTSTR lpszMsg)
 {
-    CHAR    chMsg[256];
+    LPTSTR chMsg[256];
     HANDLE  hEventSource;
     LPTSTR  lpszStrings[2];
 
@@ -63,7 +63,11 @@ nt_rpc_report(LPTSTR lpszMsg)
     hEventSource = RegisterEventSource(NULL,
                             TEXT("rpc.dll"));
 
-    sprintf(chMsg, "sunrpc report: %d", GetLastError());
+#ifdef UNICODE
+    swprintf_s(chMsg, sizeof(chMsg), L"sunrpc report: %d", GetLastError());
+#else
+    sprintf_s(chMsg, sizeof(chMsg), "sunrpc report: %d", GetLastError());
+#endif
     lpszStrings[0] = chMsg;
     lpszStrings[1] = lpszMsg;
 

--- a/oncrpc/oncrpc.vcxproj
+++ b/oncrpc/oncrpc.vcxproj
@@ -85,12 +85,13 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>TurnOffAllWarnings</WarningLevel>
-      <SDLCheck>false</SDLCheck>
+      <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;ONCRPC_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir)rpc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -104,12 +105,13 @@
       <WarningLevel>TurnOffAllWarnings</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>false</SDLCheck>
+      <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;ONCRPC_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir)rpc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -123,12 +125,13 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>TurnOffAllWarnings</WarningLevel>
-      <SDLCheck>false</SDLCheck>
+      <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;ONCRPC_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir)rpc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -142,12 +145,13 @@
       <WarningLevel>TurnOffAllWarnings</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>false</SDLCheck>
+      <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;ONCRPC_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir)rpc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/oncrpc/pmap_pro.c
+++ b/oncrpc/pmap_pro.c
@@ -118,7 +118,7 @@ xdr_pmaplist(xdrs, rp)
 	 */
 	bool_t more_elements;
 	register int freeing = (xdrs->x_op == XDR_FREE);
-	register struct pmaplist **next;
+	register struct pmaplist **next = NULL;
 
 	while (TRUE) {
 		more_elements = (bool_t)(*rp != NULL);


### PR DESCRIPTION
Use the safer `_s` methods for string operations.